### PR TITLE
Correct supported method error in the makeChange(w, r) function.

### DIFF
--- a/complete-application/main.go
+++ b/complete-application/main.go
@@ -132,7 +132,7 @@ func makeChange(w http.ResponseWriter, r *http.Request) {
 
   default:
     responseObject := make(map[string]string)
-    responseObject["message"] = "Only POST method is supported."
+    responseObject["message"] = "Only GET method is supported."
     SetWriterReturn(w, http.StatusNotImplemented, responseObject)
   }
 


### PR DESCRIPTION
It's a small change, insignificant even, but the switch statement is specifically looking for the GET method rather than the POST method.

```go
// tag::make-change-function[]
func makeChange(w http.ResponseWriter, r *http.Request) {
  response := ChangeResponse{}

  switch r.Method {
  case "GET":
    [trimmed]
  default:
    [trimmed]
  }
}
``` 